### PR TITLE
Don't add www. to blogspot

### DIFF
--- a/lib/twingly-url-normalizer.rb
+++ b/lib/twingly-url-normalizer.rb
@@ -1,6 +1,8 @@
 require 'addressable/uri'
 require 'public_suffix'
 
+PublicSuffix::List.private_domains = false
+
 module Twingly
   module URL
     class Normalizer

--- a/test/unit/normalization_test.rb
+++ b/test/unit/normalization_test.rb
@@ -117,5 +117,12 @@ class NormalizerTest < Test::Unit::TestCase
 
       assert_equal nil, result
     end
+
+    should "not add www. to blogspot blogs" do
+      url = "http://jlchen1026.blogspot.com/"
+      result = @normalizer.normalize_url(url)
+
+      assert_equal url, result
+    end
   end
 end


### PR DESCRIPTION
The [PublicSuffix library](https://github.com/weppos/publicsuffix-ruby#private-domains) will detect blogspot.com as a private TLD
unless we disable it. This caused blogspot-blogs to have www prepended
to them.

Fix #13 
