### PR TITLE
Downcase URLs in normalization

### DIFF
--- a/lib/twingly/url/normalizer.rb
+++ b/lib/twingly/url/normalizer.rb
@@ -28,7 +28,7 @@ module Twingly
           result.url.path = "/"
         end
 
-        result.url.to_s
+        result.url.to_s.downcase
       end
     end
   end

--- a/test/unit/normalization_test.rb
+++ b/test/unit/normalization_test.rb
@@ -124,5 +124,12 @@ class NormalizerTest < Test::Unit::TestCase
 
       assert_equal url, result
     end
+
+    should "downcase URL" do
+      url = "http://www.Twingly.com/"
+      result = @normalizer.normalize_url(url)
+
+      assert_equal url.downcase, result
+    end
   end
 end


### PR DESCRIPTION
URLs are not case-insensitive, but since our normalized URLs are just
used internally, it's ok. The original URL should always be used when
actually requesting a resource.

Close #8