### PR TITLE
Make sure Digest loading is thread-safe

### DIFF
--- a/lib/twingly/url/hasher.rb
+++ b/lib/twingly/url/hasher.rb
@@ -1,29 +1,34 @@
-require 'digest/md5'
-require 'digest/sha2'
+require 'digest'
 
 module Twingly
   module URL
     module Hasher
       module_function
 
+      # Instantiate digest classes in a thread-safe manner
+      # This is important since we don't know how people will
+      # use this gem (if they require it in a thread safe way)
+      MD5_DIGEST = Digest(:MD5)
+      SHA256_DIGEST = Digest(:SHA256)
+
       def taskdb_hash(url)
-        Digest::MD5.hexdigest(url)[0..29].upcase
+        MD5_DIGEST.hexdigest(url)[0..29].upcase
       end
 
       def blogstream_hash(url)
-        Digest::MD5.hexdigest(url)[0..29].upcase
+        MD5_DIGEST.hexdigest(url)[0..29].upcase
       end
 
       def documentdb_hash(url)
-        Digest::SHA256.digest(url).unpack("L!")[0]
+        SHA256_DIGEST.digest(url).unpack("L!")[0]
       end
 
       def autopingdb_hash(url)
-        Digest::SHA256.digest(url).unpack("q")[0]
+        SHA256_DIGEST.digest(url).unpack("q")[0]
       end
 
       def pingloggerdb_hash(url)
-        Digest::SHA256.digest(url).unpack("Q")[0]
+        SHA256_DIGEST.digest(url).unpack("Q")[0]
       end
     end
   end


### PR DESCRIPTION
I'm defining the hashers in constants to avoid any performance overhead
by the mutex since we hash a lot of URLs

Digest() is only thread safe in Ruby 2.2.0 and newer. Patch: https://github.com/ruby/ruby/commit/c02fa39463a0c6bf698b01bc610135604aca2ff4

I tried creating a test for this, but it's hard to provoke the error
with the old code to verify the test.

The patch version number needs a bump when this goes in.

Closes #20