### PR TITLE
Refactor requires

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,10 +16,21 @@ end
 begin
   require "rspec/core/rake_task"
 
-  task default: "spec"
+  spec_files = Dir.glob(File.join("**", "*_spec.rb"))
+  spec_tasks = []
 
-  RSpec::Core::RakeTask.new(:spec) do |task|
-    task.pattern = "spec/lib/**/*_spec.rb"
+  namespace(:spec) do
+    spec_files.each do |spec_file|
+      task_name = File.basename(spec_file, ".rb").to_sym
+
+      spec_tasks << "spec:#{task_name}"
+
+      RSpec::Core::RakeTask.new(task_name) do |task|
+        task.pattern = spec_file
+      end
+    end
   end
+
+  task default: spec_tasks.shuffle
 rescue LoadError
 end

--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,7 @@ end
 begin
   require "rspec/core/rake_task"
 
-  spec_files = Dir.glob(File.join("**", "*_spec.rb"))
+  spec_files = Dir.glob(File.join("spec/**", "*_spec.rb"))
   spec_tasks = []
 
   namespace(:spec) do

--- a/lib/twingly/url/null_url.rb
+++ b/lib/twingly/url/null_url.rb
@@ -1,3 +1,5 @@
+require "twingly/url"
+
 module Twingly
   class URL
     class NullURL

--- a/lib/twingly/url/null_url.rb
+++ b/lib/twingly/url/null_url.rb
@@ -1,4 +1,4 @@
-require "twingly/url"
+require_relative "../url"
 
 module Twingly
   class URL

--- a/lib/twingly/url/utilities.rb
+++ b/lib/twingly/url/utilities.rb
@@ -1,3 +1,5 @@
+require_relative "../url"
+
 module Twingly
   class URL
     module Utilities

--- a/spec/lib/twingly/url/hasher_spec.rb
+++ b/spec/lib/twingly/url/hasher_spec.rb
@@ -1,5 +1,7 @@
 require "spec_helper"
 
+require "twingly/url/hasher"
+
 describe Twingly::URL::Hasher do
   describe ".taskdb_hash" do
     it "returns a MD5 hexdigest" do

--- a/spec/lib/twingly/url/null_url_spec.rb
+++ b/spec/lib/twingly/url/null_url_spec.rb
@@ -1,5 +1,7 @@
 require "spec_helper"
 
+require "twingly/url/null_url"
+
 describe Twingly::URL::NullURL do
   let(:url) { described_class.new }
 

--- a/spec/lib/twingly/url/utilities_spec.rb
+++ b/spec/lib/twingly/url/utilities_spec.rb
@@ -1,5 +1,7 @@
 require "spec_helper"
 
+require "twingly/url/utilities"
+
 describe Twingly::URL::Utilities do
   describe ".extract_valid_urls" do
     context "when given a string with URLs" do

--- a/spec/lib/twingly/url_spec.rb
+++ b/spec/lib/twingly/url_spec.rb
@@ -1,5 +1,7 @@
 require "spec_helper"
 
+require "twingly/url"
+
 def invalid_urls
   [
     "http://http",

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,3 @@
-require "twingly/url"
-require "twingly/url/null_url"
-require "twingly/url/hasher"
-require "twingly/url/utilities"
-
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true


### PR DESCRIPTION
With the refactoring of spec_helper, a bug like this can now be caught by 

    bundle exec rspec spec/lib/twingly/url/utilities_spec.rb

but I did not succeed in catching it in 

    bundle exec rake

We can continue to work on that from this.

Close #56.