### PR TITLE
Fix "#valid? doesn't work for protocol-less urls"

### DIFF
--- a/lib/twingly/url.rb
+++ b/lib/twingly/url.rb
@@ -100,7 +100,7 @@ module Twingly
     end
 
     def normalized_scheme
-      addressable_uri.scheme.downcase
+      scheme.downcase
     end
 
     def normalized_host

--- a/lib/twingly/url.rb
+++ b/lib/twingly/url.rb
@@ -24,20 +24,24 @@ module Twingly
     end
 
     def self.internal_parse(potential_url)
-      if potential_url.is_a?(Addressable::URI)
-        addressable_uri = potential_url
-      else
-        addressable_uri = Addressable::URI.heuristic_parse(potential_url)
-      end
-
+      addressable_uri = to_addressable_uri(potential_url)
       raise Twingly::Error::ParseError if addressable_uri.nil?
 
       public_suffix_domain = PublicSuffix.parse(addressable_uri.display_uri.host)
+      raise Twingly::Error::ParseError if public_suffix_domain.nil?
 
       self.new(addressable_uri, public_suffix_domain)
     rescue Addressable::URI::InvalidURIError, PublicSuffix::DomainInvalid => error
       error.extend(Twingly::URL::Error)
       raise
+    end
+
+    def self.to_addressable_uri(potential_url)
+     if potential_url.is_a?(Addressable::URI)
+        potential_url
+      else
+        Addressable::URI.heuristic_parse(potential_url)
+      end
     end
 
     def initialize(addressable_uri, public_suffix_domain)
@@ -123,7 +127,7 @@ module Twingly
     end
 
     def valid?
-      addressable_uri && public_suffix_domain && SCHEMES.include?(normalized_scheme)
+      SCHEMES.include?(normalized_scheme)
     end
 
     def <=>(other)

--- a/lib/twingly/url.rb
+++ b/lib/twingly/url.rb
@@ -36,14 +36,6 @@ module Twingly
       raise
     end
 
-    def self.to_addressable_uri(potential_url)
-     if potential_url.is_a?(Addressable::URI)
-        potential_url
-      else
-        Addressable::URI.heuristic_parse(potential_url)
-      end
-    end
-
     def initialize(addressable_uri, public_suffix_domain)
       unless addressable_uri.is_a?(Addressable::URI)
         raise ArgumentError, "First parameter must be an Addressable::URI"
@@ -140,6 +132,15 @@ module Twingly
 
     def inspect
       sprintf("#<%s:0x%x %s>", self.class.name, __id__, self.to_s)
+    end
+
+    private_class_method \
+    def self.to_addressable_uri(potential_url)
+     if potential_url.is_a?(Addressable::URI)
+        potential_url
+      else
+        Addressable::URI.heuristic_parse(potential_url)
+      end
     end
 
     private

--- a/lib/twingly/url.rb
+++ b/lib/twingly/url.rb
@@ -10,7 +10,7 @@ module Twingly
   class URL
     include Comparable
 
-    SCHEMES = %w(http https)
+    ACCEPTED_SCHEMES = /\Ahttps?\z/i
     ENDS_WITH_SLASH = /\/+$/
 
     def self.parse(potential_url)
@@ -127,7 +127,7 @@ module Twingly
     end
 
     def valid?
-      SCHEMES.include?(normalized_scheme)
+      !!(scheme =~ ACCEPTED_SCHEMES)
     end
 
     def <=>(other)

--- a/lib/twingly/url.rb
+++ b/lib/twingly/url.rb
@@ -25,10 +25,10 @@ module Twingly
 
     def self.internal_parse(potential_url)
       addressable_uri = to_addressable_uri(potential_url)
-      raise Twingly::Error::ParseError if addressable_uri.nil?
+      raise Twingly::URL::Error::ParseError if addressable_uri.nil?
 
       public_suffix_domain = PublicSuffix.parse(addressable_uri.display_uri.host)
-      raise Twingly::Error::ParseError if public_suffix_domain.nil?
+      raise Twingly::URL::Error::ParseError if public_suffix_domain.nil?
 
       scheme = addressable_uri.scheme
       raise Twingly::URL::Error::ParseError unless scheme =~ ACCEPTED_SCHEMES

--- a/lib/twingly/url.rb
+++ b/lib/twingly/url.rb
@@ -30,6 +30,9 @@ module Twingly
       public_suffix_domain = PublicSuffix.parse(addressable_uri.display_uri.host)
       raise Twingly::Error::ParseError if public_suffix_domain.nil?
 
+      scheme = addressable_uri.scheme
+      raise Twingly::URL::Error::ParseError unless scheme =~ ACCEPTED_SCHEMES
+
       self.new(addressable_uri, public_suffix_domain)
     rescue Addressable::URI::InvalidURIError, PublicSuffix::DomainInvalid => error
       error.extend(Twingly::URL::Error)
@@ -119,7 +122,7 @@ module Twingly
     end
 
     def valid?
-      !!(scheme =~ ACCEPTED_SCHEMES)
+      true
     end
 
     def <=>(other)

--- a/spec/lib/twingly/url_spec.rb
+++ b/spec/lib/twingly/url_spec.rb
@@ -105,20 +105,6 @@ describe Twingly::URL do
     end
   end
 
-  describe ".to_addressable_uri" do
-    let(:adressable_uri) { Addressable::URI.parse(test_url) }
-
-    context "when given Addressable::URI" do
-      subject { described_class.to_addressable_uri(adressable_uri) }
-      it { is_expected.to eq(adressable_uri) }
-    end
-
-    context "when given string" do
-      subject { described_class.to_addressable_uri(test_url) }
-      it { is_expected.to eq(adressable_uri) }
-    end
-  end
-
   describe "#initialize" do
     context "when given input parameters of wrong types" do
       it "raises an error" do

--- a/spec/lib/twingly/url_spec.rb
+++ b/spec/lib/twingly/url_spec.rb
@@ -104,6 +104,20 @@ describe Twingly::URL do
     end
   end
 
+  describe ".to_addressable_uri" do
+    let(:adressable_uri) { Addressable::URI.parse(test_url) }
+
+    context "when given Addressable::URI" do
+      subject { described_class.to_addressable_uri(adressable_uri) }
+      it { is_expected.to eq(adressable_uri) }
+    end
+
+    context "when given string" do
+      subject { described_class.to_addressable_uri(test_url) }
+      it { is_expected.to eq(adressable_uri) }
+    end
+  end
+
   describe "#initialize" do
     context "when given input parameters of wrong types" do
       it "raises an error" do

--- a/spec/lib/twingly/url_spec.rb
+++ b/spec/lib/twingly/url_spec.rb
@@ -373,20 +373,6 @@ describe Twingly::URL do
   describe "#without_scheme" do
     subject { described_class.parse(url).without_scheme }
 
-    context "removes scheme from non HTTP(S) URLs" do
-      let(:url)      { "gopher://www.duh.se/" }
-      let(:expected) { "//www.duh.se/" }
-
-      it { is_expected.to eq(expected) }
-    end
-
-    context "removes scheme from non HTTP(S) URLs with parameter" do
-      let(:url)      { "ftp://ftp.example.com/?url=https://www.example.com/" }
-      let(:expected) { "//ftp.example.com/?url=https://www.example.com/" }
-
-      it { is_expected.to eq(expected) }
-    end
-
     context "removes scheme from mixed case HTTP URL" do
       let(:url)      { "HttP://www.duh.se/" }
       let(:expected) { "//www.duh.se/" }

--- a/spec/lib/twingly/url_spec.rb
+++ b/spec/lib/twingly/url_spec.rb
@@ -21,6 +21,7 @@ def invalid_urls
     "blablahttp://blog.twingly.com/",
     "gopher://blog.twingly.com/",
     "\n",
+    "//www.twingly.com/",
   ]
 end
 

--- a/spec/lib/twingly/url_spec.rb
+++ b/spec/lib/twingly/url_spec.rb
@@ -105,6 +105,14 @@ describe Twingly::URL do
     end
   end
 
+  describe ".internal_parse" do
+    context "when given nil" do
+      it "raises an error" do
+        expect { described_class.internal_parse(nil) }.to raise_error(Twingly::URL::Error::ParseError)
+      end
+    end
+  end
+
   describe "#initialize" do
     context "when given input parameters of wrong types" do
       it "raises an error" do

--- a/spec/lib/twingly/url_spec.rb
+++ b/spec/lib/twingly/url_spec.rb
@@ -55,11 +55,11 @@ describe Twingly::URL do
     end
 
     context "when given bad input" do
-      let(:invalid_url) { "banan" }
-
-      it "returns a null URL" do
-        actual = described_class.parse(invalid_url)
-        expect(actual).to be_a(Twingly::URL::NullURL)
+      invalid_urls.each do |invalid_url|
+        it "returns a NullURL for \"#{invalid_url}\"" do
+          actual = described_class.parse(invalid_url)
+          expect(actual).to be_a(Twingly::URL::NullURL)
+        end
       end
     end
 


### PR DESCRIPTION
There were lots of options to go with there:

* nil check in #scheme or #normalized_scheme
* .to_s in #scheme or #normalized_scheme
* use Addressable’s #normalized_scheme

I don’t think nil checks are that pretty, so that one was quickly discarded. I also don’t think we should #to_s “randomly” for some properties it’s either all or nothing in my opinion. Using Addressable’s own #normalized_scheme was the top candidate, but it did additional things to the url (not just downcasing it) and I think it’s a good thing that we try to control what we can when it comes to normalization.

So ultimately I went with this, I changed so that we check against #scheme instead of #normalized_scheme as that makes a whole lot of sense to me at least.

Fix #55.

Additionally, I did some refactoring which I felt was related to fixing this issue.