### PR TITLE
Improve punycode handling with libidn

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Twingly URL tools.
 
 The gem requires libidn.
 
-    sudo apt-get install idn # Debian/Ubuntu
+    sudo apt-get install libidn11 # Ubuntu
     brew install libidn # OS X
 
 ## Tests

--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ Twingly URL tools.
 
     gem install twingly-url
 
+### Dependencies
+
+The gem requires libidn.
+
+    sudo apt-get install idn # Debian/Ubuntu
+    brew install libidn # OS X
+
 ## Tests
 
 Run tests with

--- a/lib/twingly/url.rb
+++ b/lib/twingly/url.rb
@@ -27,11 +27,11 @@ module Twingly
       addressable_uri = to_addressable_uri(potential_url)
       raise Twingly::URL::Error::ParseError if addressable_uri.nil?
 
-      public_suffix_domain = PublicSuffix.parse(addressable_uri.display_uri.host)
-      raise Twingly::URL::Error::ParseError if public_suffix_domain.nil?
-
       scheme = addressable_uri.scheme
       raise Twingly::URL::Error::ParseError unless scheme =~ ACCEPTED_SCHEMES
+
+      public_suffix_domain = PublicSuffix.parse(addressable_uri.display_uri.host)
+      raise Twingly::URL::Error::ParseError if public_suffix_domain.nil?
 
       self.new(addressable_uri, public_suffix_domain)
     rescue Addressable::URI::InvalidURIError, PublicSuffix::DomainInvalid => error

--- a/lib/twingly/url.rb
+++ b/lib/twingly/url.rb
@@ -1,4 +1,5 @@
 require "addressable/uri"
+require "addressable/idna/native"
 require "public_suffix"
 
 require_relative "url/null_url"

--- a/spec/lib/twingly/url_spec.rb
+++ b/spec/lib/twingly/url_spec.rb
@@ -24,6 +24,8 @@ def invalid_urls
     "gopher://blog.twingly.com/",
     "\n",
     "//www.twingly.com/",
+    "http://xn--t...-/",
+    "http://xn--...-"
   ]
 end
 
@@ -34,6 +36,7 @@ def valid_urls
     "hTTP://blog.twingly.com/",
     "https://blog.twingly.com",
     "http://3.bp.blogspot.com/_lRbEHeizXlQ/Sf4RdEqCqhI/AAAAAAAAAAw/Pl8nGPsyhXc/s1600-h/images[4].jpg",
+    "http://xn--zckp1cyg1.sblo.jp/",
   ]
 end
 

--- a/twingly-url.gemspec
+++ b/twingly-url.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "addressable", "~> 2"
   s.add_dependency "public_suffix", "~> 1.4"
+  s.add_dependency "idn-ruby", "~> 0.1"
 
   s.add_development_dependency "rake", "~> 10"
   s.add_development_dependency "rspec", "~> 3"


### PR DESCRIPTION
Requires libidn.

We need to verify that it works in the current locations:

* [x] Travis
* [x] ~~Heroku (will try in production)~~ 
* [x] ~~Datacenter (will try in production)~~ 

Fixes #48.