### PR TITLE
The gem should load the version constant

### DIFF
--- a/lib/twingly/url.rb
+++ b/lib/twingly/url.rb
@@ -4,6 +4,7 @@ require "public_suffix"
 
 require_relative "url/null_url"
 require_relative "url/error"
+require_relative "version"
 
 PublicSuffix::List.private_domains = false
 

--- a/lib/twingly/url/hasher.rb
+++ b/lib/twingly/url/hasher.rb
@@ -1,5 +1,7 @@
 require 'digest'
 
+require_relative "../url"
+
 module Twingly
   class URL
     module Hasher


### PR DESCRIPTION
Without this

    $ pry -r ./lib/twingly/url.rb
    [1] pry(main)> Twingly::URL::VERSION
    NameError: uninitialized constant Twingly::URL::VERSION
    from (pry):1:in `__pry__'

With this

    $ pry -r ./lib/twingly/url.rb
    [1] pry(main)> Twingly::URL::VERSION
    => "3.0.2"