### PR TITLE
No part of a URL should be nil

### DIFF
--- a/lib/twingly/url.rb
+++ b/lib/twingly/url.rb
@@ -39,7 +39,7 @@ module Twingly
         raise Twingly::URL::Error::ParseError if public_suffix_domain.nil?
 
         raise Twingly::URL::Error::ParseError unless public_suffix_domain.sld
-
+        puts addressable_uri.origin
         new(addressable_uri, public_suffix_domain)
       rescue *ERRORS => error
         error.extend(Twingly::URL::Error)
@@ -67,35 +67,35 @@ module Twingly
     end
 
     def scheme
-      addressable_uri.scheme
+      addressable_uri.scheme.to_s
     end
 
     def trd
-      public_suffix_domain.trd
+      public_suffix_domain.trd.to_s
     end
 
     def sld
-      public_suffix_domain.sld
+      public_suffix_domain.sld.to_s
     end
 
     def tld
-      public_suffix_domain.tld
+      public_suffix_domain.tld.to_s
     end
 
     def domain
-      public_suffix_domain.domain
+      public_suffix_domain.domain.to_s
     end
 
     def host
-      addressable_uri.host
+      addressable_uri.host.to_s
     end
 
     def origin
-      addressable_uri.origin
+      addressable_uri.origin.to_s
     end
 
     def path
-      addressable_uri.path
+      addressable_uri.path.to_s
     end
 
     def without_scheme

--- a/lib/twingly/url.rb
+++ b/lib/twingly/url.rb
@@ -39,7 +39,7 @@ module Twingly
         raise Twingly::URL::Error::ParseError if public_suffix_domain.nil?
 
         raise Twingly::URL::Error::ParseError unless public_suffix_domain.sld
-        puts addressable_uri.origin
+
         new(addressable_uri, public_suffix_domain)
       rescue *ERRORS => error
         error.extend(Twingly::URL::Error)

--- a/lib/twingly/url.rb
+++ b/lib/twingly/url.rb
@@ -67,7 +67,7 @@ module Twingly
     end
 
     def scheme
-      addressable_uri.scheme.to_s
+      addressable_uri.scheme
     end
 
     def trd
@@ -75,27 +75,27 @@ module Twingly
     end
 
     def sld
-      public_suffix_domain.sld.to_s
+      public_suffix_domain.sld
     end
 
     def tld
-      public_suffix_domain.tld.to_s
+      public_suffix_domain.tld
     end
 
     def domain
-      public_suffix_domain.domain.to_s
+      public_suffix_domain.domain
     end
 
     def host
-      addressable_uri.host.to_s
+      addressable_uri.host
     end
 
     def origin
-      addressable_uri.origin.to_s
+      addressable_uri.origin
     end
 
     def path
-      addressable_uri.path.to_s
+      addressable_uri.path
     end
 
     def without_scheme

--- a/lib/twingly/url.rb
+++ b/lib/twingly/url.rb
@@ -38,7 +38,7 @@ module Twingly
         public_suffix_domain = PublicSuffix.parse(addressable_uri.display_uri.host)
         raise Twingly::URL::Error::ParseError if public_suffix_domain.nil?
 
-        raise Twingly::URL::Error::ParseError unless public_suffix_domain.sld
+        raise Twingly::URL::Error::ParseError if public_suffix_domain.sld.nil?
 
         new(addressable_uri, public_suffix_domain)
       rescue *ERRORS => error

--- a/lib/twingly/url.rb
+++ b/lib/twingly/url.rb
@@ -38,6 +38,8 @@ module Twingly
         public_suffix_domain = PublicSuffix.parse(addressable_uri.display_uri.host)
         raise Twingly::URL::Error::ParseError if public_suffix_domain.nil?
 
+        raise Twingly::URL::Error::ParseError unless public_suffix_domain.sld
+
         new(addressable_uri, public_suffix_domain)
       rescue *ERRORS => error
         error.extend(Twingly::URL::Error)

--- a/spec/lib/twingly/url_spec.rb
+++ b/spec/lib/twingly/url_spec.rb
@@ -148,6 +148,12 @@ describe Twingly::URL do
   describe "#trd" do
     subject { url.trd }
     it { is_expected.to eq("www.blog") }
+
+    context "when the url contains no trd" do
+      let(:test_url){ "http://twingly.com" }
+
+      it { is_expected.to eq("") }
+    end
   end
 
   describe "#sld" do

--- a/spec/lib/twingly/url_spec.rb
+++ b/spec/lib/twingly/url_spec.rb
@@ -27,6 +27,14 @@ def invalid_urls
     "http://xn--t...-/",
     "http://xn--...-",
     "leather beltsbelts for menleather beltmens beltsleather belts for menmens beltbelt bucklesblack l...",
+    "https//.com",
+    "http://xxx@.com/",
+    "http://...com",
+    "http://.ly/xxx",
+    "http://.com.my/",
+    "http://.net",
+    "http://.com.",
+    "http://.gl/xxx",
   ]
 end
 


### PR DESCRIPTION
An attempt to fix #52

* URLs without `sld` now results in a `NullURL`. (Im not sure whether my assumption here is correct, but it works for the URLs given as examples in #52)
* Added `.to_s` to `#trd`