### PR TITLE
Temporary fix for UTF-8 bug in addressable

### DIFF
--- a/lib/twingly/url.rb
+++ b/lib/twingly/url.rb
@@ -35,7 +35,9 @@ module Twingly
         scheme = addressable_uri.scheme
         raise Twingly::URL::Error::ParseError unless scheme =~ ACCEPTED_SCHEMES
 
-        public_suffix_domain = PublicSuffix.parse(addressable_uri.display_uri.host)
+        display_uri = addressable_display_uri(addressable_uri)
+
+        public_suffix_domain = PublicSuffix.parse(display_uri.host)
         raise Twingly::URL::Error::ParseError if public_suffix_domain.nil?
 
         new(addressable_uri, public_suffix_domain)
@@ -56,7 +58,19 @@ module Twingly
         end
       end
 
-      private :new, :internal_parse, :to_addressable_uri
+      # Workaround for the following bug in addressable:
+      # https://github.com/sporkmonger/addressable/issues/224
+      def addressable_display_uri(addressable_uri)
+        addressable_uri.display_uri
+      rescue ArgumentError => error
+        if error.message.include?("invalid byte sequence in UTF-8")
+          raise Twingly::URL::Error::ParseError
+        end
+
+        raise
+      end
+
+      private :new, :internal_parse, :to_addressable_uri, :addressable_display_uri
     end
 
     def initialize(addressable_uri, public_suffix_domain)

--- a/lib/twingly/url.rb
+++ b/lib/twingly/url.rb
@@ -70,7 +70,10 @@ module Twingly
         raise
       end
 
-      private :new, :internal_parse, :to_addressable_uri, :addressable_display_uri
+      private :new
+      private :internal_parse
+      private :to_addressable_uri
+      private :addressable_display_uri
     end
 
     def initialize(addressable_uri, public_suffix_domain)

--- a/spec/lib/twingly/url_spec.rb
+++ b/spec/lib/twingly/url_spec.rb
@@ -27,6 +27,8 @@ def invalid_urls
     "http://xn--t...-/",
     "http://xn--...-",
     "leather beltsbelts for menleather beltmens beltsleather belts for menmens beltbelt bucklesblack l...",
+    "http://some_site.net%C2",
+    "http://+%D5d.some_site.net",
   ]
 end
 


### PR DESCRIPTION
Temporary fix for #62.

Related to sporkmonger/addressable#224

Used the code in https://github.com/twingly/twingly-url/issues/62#issuecomment-176830731 as inspiration, but I had to modify it so we didn't have to call `addressable.display_uri` twice.