### PR TITLE
Drop libidn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: ruby
 sudo: false
 
 rvm:
+  - jruby-9.0.5.0
+  - jruby-9.1.5.0
   - 2.2.5
   - 2.3.1
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,13 @@ rvm:
   - 2.3.1
   - ruby-2.4.0-preview2
   - ruby-2.4.0-preview2-clang
+  - jruby-head
   - ruby-head
   - ruby-head-clang
 
 matrix:
   allow_failures:
+    - rvm: jruby-head
     - rvm: ruby-2.4.0-preview2
     - rvm: ruby-2.4.0-preview2-clang
     - rvm: ruby-head

--- a/README.md
+++ b/README.md
@@ -157,10 +157,7 @@ url.normalized.to_s           # => "https://admin:correcthorsebatterystaple@www.
 
 ### Dependencies
 
-The gem requires libidn.
-
-    sudo apt-get install libidn11 # Ubuntu
-    brew install libidn # OS X
+Only the gems listed in the [Gem Specification](https://github.com/twingly/twingly-url/blob/master/twingly-url.gemspec).
 
 ## Development
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,9 @@
 require "bundler/gem_tasks"
 
 namespace :profile do
-  require_relative "profile/profile"
-
   desc "Profile"
   task :normalize do |task|
+    require_relative "profile/profile"
     require_relative "lib/twingly/url"
 
     Profile.measure "normalizing a short URL", 1000 do

--- a/lib/twingly/url.rb
+++ b/lib/twingly/url.rb
@@ -1,5 +1,4 @@
 require "addressable/uri"
-require "addressable/idna/native"
 require "public_suffix"
 
 require_relative "public_suffix_list"
@@ -17,7 +16,6 @@ module Twingly
     ERRORS_TO_EXTEND = [
       Addressable::URI::InvalidURIError,
       PublicSuffix::DomainInvalid,
-      IDN::Idna::IdnaError,
     ]
 
     private_constant :ACCEPTED_SCHEMES

--- a/spec/lib/twingly/url_spec.rb
+++ b/spec/lib/twingly/url_spec.rb
@@ -114,6 +114,16 @@ describe Twingly::URL do
       end
     end
 
+    context "IDNA 2003 vs IDNA 2008" do
+      describe "if you normalize a URL with the domain \"straße.de\"" do
+        let(:test_url) { "http://straße.de" }
+
+        it "the domain of the normalized URL should be \"xn--strae-oqa.de\"" do
+          expect(subject.normalized.domain).to eq("xn--strae-oqa.de")
+        end
+      end
+    end
+
     context "when given badly encoded input" do
       let(:badly_encoded_url) { "http://abc.se/öあ\x81b\xE3" }
       let(:expected)          { "http://abc.se/öあ\uFFFDb\uFFFD" }

--- a/spec/lib/twingly/url_spec.rb
+++ b/spec/lib/twingly/url_spec.rb
@@ -42,9 +42,6 @@ def invalid_urls
     # https://github.com/sporkmonger/addressable/issues/224
     "http://some_site.net%C2",
     "http://+%D5d.some_site.net",
-
-    # Triggers IDN::Idna::IdnaError: Output would be too large or too small (5)
-    "http://AcinusFallumTrompetumNullunCreditumVisumEstAtCuadLongumEtCefallumEst.com",
   ]
 end
 
@@ -63,6 +60,21 @@ def valid_urls
     "http://:@blog.twingly.com/",
     "https://www.foo.ایران.ir/bar",
     "https://www.foo.xn--mgba3a4f16a.ir/bar",
+
+    # The following URL triggers
+    #
+    #   IDN::Idna::IdnaError: Output would be too large or too small (5)
+    #
+    # when used with Addressable and libidn (IDNA 2003)
+    # but considered valid with the pure Ruby IDNA solution in Addressable.
+    #
+    # This inconsistency has as been reported at
+    # https://github.com/sporkmonger/addressable/issues/239
+    #
+    # Long names like this will probably not resolv, see comments at
+    # https://github.com/twingly/twingly-url/issues/66#issuecomment-246349029
+    # but for now as addressable considers them valid, we do the same.
+    "http://AcinusFallumTrompetumNullunCreditumVisumEstAtCuadLongumEtCefallumEst.com",
   ]
 end
 

--- a/spec/lib/twingly/url_spec.rb
+++ b/spec/lib/twingly/url_spec.rb
@@ -114,16 +114,6 @@ describe Twingly::URL do
       end
     end
 
-    context "IDNA 2003 vs IDNA 2008" do
-      describe "if you normalize a URL with the domain \"straße.de\"" do
-        let(:test_url) { "http://straße.de" }
-
-        it "the domain of the normalized URL should be \"xn--strae-oqa.de\"" do
-          expect(subject.normalized.domain).to eq("xn--strae-oqa.de")
-        end
-      end
-    end
-
     context "when given badly encoded input" do
       let(:badly_encoded_url) { "http://abc.se/öあ\x81b\xE3" }
       let(:expected)          { "http://abc.se/öあ\uFFFDb\uFFFD" }
@@ -384,6 +374,15 @@ describe Twingly::URL do
     end
 
     subject { described_class.parse(url).normalized.to_s }
+
+    context "when given IDN URL with the domain \"straße.de\"" do
+      let(:test_url) { "http://straße.de" }
+      let(:normalized_url) { described_class.parse(url).normalized }
+
+      it "does conform to the IDNA2008 protocol" do
+        expect(normalized_url.domain).to eq("xn--strae-oqa.de")
+      end
+    end
 
     context "with URL that has an internationalized TLD in Unicode" do
       let(:test_url) { "https://www.foo.ایران.ir/bar" }

--- a/twingly-url.gemspec
+++ b/twingly-url.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "addressable", "~> 2.4", ">= 2.4.0"
   s.add_dependency "public_suffix", "~> 2.0", ">= 2.0.2"
-  s.add_dependency "idn-ruby", "~> 0.1"
 
   s.add_development_dependency "rake", "~> 10"
   s.add_development_dependency "rspec", "~> 3"

--- a/twingly-url.gemspec
+++ b/twingly-url.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rake", "~> 10"
   s.add_development_dependency "rspec", "~> 3"
-  s.add_development_dependency "ruby-prof", "~> 0"
+  s.add_development_dependency "ruby-prof", "~> 0" unless RUBY_PLATFORM == "java"
   s.add_development_dependency "pry"
 
   s.files        = Dir.glob("{lib}/**/*") + %w(README.md)


### PR DESCRIPTION
Instead, we use the pure Ruby IDNA solution in addressable.

Close #66.