### PR TITLE
Remove ruby-prof from dev dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,8 @@ rdoc
 spec/reports
 test/tmp
 test/version_tmp
-tmp
+/tmp
+/profile/tmp
 
 # YARD artifacts
 .yardoc

--- a/README.md
+++ b/README.md
@@ -180,7 +180,9 @@ Run tests with
 
 You can get some profiling by running
 
-    bundle exec rake profile:normalize
+    cd profile/
+    bundle
+    bundle exec rake
 
 Note that this isn't a benchmark, we're using [ruby-prof] which will slow things down.
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,17 +1,5 @@
+# Bundler rake tasks to handle gem releases
 require "bundler/gem_tasks"
-
-namespace :profile do
-  require_relative "profile/profile"
-
-  desc "Profile"
-  task :normalize do |task|
-    require_relative "lib/twingly/url"
-
-    Profile.measure "normalizing a short URL", 1000 do
-      Twingly::URL.parse('http://www.duh.se/').normalized
-    end
-  end
-end
 
 begin
   require "rspec/core/rake_task"

--- a/profile/Gemfile
+++ b/profile/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org/"
+
+gem "rake"
+gem "ruby-prof"
+gem "twingly-url", path: "../"

--- a/profile/Rakefile
+++ b/profile/Rakefile
@@ -1,0 +1,13 @@
+require "twingly/url"
+require_relative "profile"
+
+namespace :profile do
+  desc "Profile"
+  task :normalize do |task|
+    Profile.measure "normalizing a short URL", 1000 do
+      Twingly::URL.parse('http://www.duh.se/').normalized
+    end
+  end
+end
+
+task default: "profile:normalize"

--- a/twingly-url.gemspec
+++ b/twingly-url.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rake", "~> 10"
   s.add_development_dependency "rspec", "~> 3"
-  s.add_development_dependency "ruby-prof", "~> 0"
   s.add_development_dependency "pry"
 
   s.files        = Dir.glob("{lib}/**/*") + %w(README.md)


### PR DESCRIPTION
Was problematic for a number of reasons, see #92.

Close #92.