### PR TITLE
Depend on addressable 2.5.0 and public_suffix 2.0.3

### DIFF
--- a/lib/twingly/url.rb
+++ b/lib/twingly/url.rb
@@ -59,7 +59,6 @@ module Twingly
         else
           potential_url = String(potential_url)
           potential_url = potential_url.scrub
-          potential_url = potential_url.strip
 
           Addressable::URI.heuristic_parse(potential_url)
         end

--- a/spec/lib/twingly/url_spec.rb
+++ b/spec/lib/twingly/url_spec.rb
@@ -61,20 +61,6 @@ def valid_urls
     "http://:@blog.twingly.com/",
     "https://www.foo.ایران.ir/bar",
     "https://www.foo.xn--mgba3a4f16a.ir/bar",
-
-    # The following URL triggers
-    #
-    #   IDN::Idna::IdnaError: Output would be too large or too small (5)
-    #
-    # when used with Addressable and libidn (IDNA 2003)
-    # but considered valid with the pure Ruby IDNA solution in Addressable.
-    #
-    # This inconsistency has as been reported at
-    # https://github.com/sporkmonger/addressable/issues/239
-    #
-    # Long names like this will probably not resolv, see comments at
-    # https://github.com/twingly/twingly-url/issues/66#issuecomment-246349029
-    # but for now as addressable considers them valid, we do the same.
     "http://AcinusFallumTrompetumNullunCreditumVisumEstAtCuadLongumEtCefallumEst.com",
   ]
 end

--- a/twingly-url.gemspec
+++ b/twingly-url.gemspec
@@ -12,8 +12,8 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
   s.required_ruby_version = "~> 2.2"
 
-  s.add_dependency "addressable", "= 2.4.0"
-  s.add_dependency "public_suffix", "= 2.0.2"
+  s.add_dependency "addressable", "= 2.5.0"
+  s.add_dependency "public_suffix", "= 2.0.3"
 
   s.add_development_dependency "rake", "~> 10"
   s.add_development_dependency "rspec", "~> 3"


### PR DESCRIPTION
From https://github.com/sporkmonger/addressable/blob/master/CHANGELOG.md#addressable-250

> - dropping support for Ruby 1.9
> - adding support for Ruby 2.4 preview
> - add support for public suffixes and tld; first runtime dependency
> - hostname escaping should match RFC; underscores in hostnames no
>   longer escaped
> - paths beginning with // and missing an authority are now considered
>   invalid
> - validation now also takes place after setting a path
> - handle backslashes in authority more like a browser for
>   `heuristic_parse`
> - unescaped backslashes in host now raise an `InvalidURIError`
> - `merge!`, `join!`, `omit!` and `normalize!` don't disable deferred
>   validation
> - `heuristic_parse` now trims whitespace before parsing
> - host parts longer than 63 bytes will be ignored and not passed to
>   libidn
> - normalized values always encoded as UTF-8

From https://github.com/weppos/publicsuffix-ruby/blob/master/CHANGELOG.md#release-203

> - CHANGED: Updated definitions.