### PR TITLE
Update PublicSuffix and Addressable

### DIFF
--- a/lib/twingly/public_suffix_list.rb
+++ b/lib/twingly/public_suffix_list.rb
@@ -15,17 +15,15 @@ module Twingly
 
       punycoded_names(list).each do |punycoded_name|
         new_rule = PublicSuffix::Rule.factory(punycoded_name)
-        list.add(new_rule, reindex: false)
+        list.add(new_rule)
       end
-
-      list.reindex!
 
       list
     end
 
     private_class_method \
     def self.punycoded_names(list)
-      names = list.map { |rule| Addressable::IDNA.to_ascii(rule.value) }
+      names = list.each.map { |rule| Addressable::IDNA.to_ascii(rule.value) }
       names.select { |name| punycoded_name?(name) }
     end
 

--- a/twingly-url.gemspec
+++ b/twingly-url.gemspec
@@ -12,8 +12,8 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
   s.required_ruby_version = "~> 2.2"
 
-  s.add_dependency "addressable", "= 2.5.0"
-  s.add_dependency "public_suffix", "= 2.0.3"
+  s.add_dependency "addressable", "= 2.5.2"
+  s.add_dependency "public_suffix", "= 3.0.1"
 
   s.add_development_dependency "rake", "~> 10"
   s.add_development_dependency "rspec", "~> 3"


### PR DESCRIPTION
Unfortunately it doesn't look like this fixes any of our issues, but since it made the profiling run a bit faster (and the fact that the tests didn't break) I made a PR of this anyway.

Profiling "total run time" went from `1.6663s` to `1.4801s`.

Some related links:

* https://github.com/weppos/publicsuffix-ruby/pull/130
* https://github.com/weppos/publicsuffix-ruby/pull/133
* https://github.com/sporkmonger/addressable/pull/267