### PR TITLE
Load the pure-Ruby IDNA implementation from Addressable

### DIFF
--- a/lib/twingly/url.rb
+++ b/lib/twingly/url.rb
@@ -1,4 +1,4 @@
-require "addressable/idna"
+require "addressable/idna/pure"
 require "addressable/uri"
 require "public_suffix"
 


### PR DESCRIPTION
Since #113, twingly-url can only be used with the pure-Ruby implementation in Addressable.

If idn-ruby (libidn wrapper gem) is installed, Addressable will not load the pure-Ruby implementation, which breaks twingly-url.

Close #119