### PR TITLE
Remove Twingly::URL::Hasher.pingloggerdb_hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ Twingly URL tools.
     * `Twingly::URL::Hasher.blogstream_hash(url)` - MD5 hexdigest
     * `Twingly::URL::Hasher.documentdb_hash(url)` - SHA256 unsigned long, native endian digest
     * `Twingly::URL::Hasher.autopingdb_hash(url)` - SHA256 64-bit signed, native endian digest
-    * `Twingly::URL::Hasher.pingloggerdb_hash(url)` - SHA256 64-bit unsigned, native endian digest
 * `twingly/url/utilities` - Utilities to work with URLs
     * `Twingly::URL::Utilities.extract_valid_urls` - Returns Array of valid `Twingly::URL`
 

--- a/lib/twingly/url/hasher.rb
+++ b/lib/twingly/url/hasher.rb
@@ -28,10 +28,6 @@ module Twingly
       def autopingdb_hash(url)
         SHA256_DIGEST.digest(url).unpack("q")[0]
       end
-
-      def pingloggerdb_hash(url)
-        SHA256_DIGEST.digest(url).unpack("Q")[0]
-      end
     end
   end
 end

--- a/spec/lib/twingly/url/hasher_spec.rb
+++ b/spec/lib/twingly/url/hasher_spec.rb
@@ -28,10 +28,4 @@ describe Twingly::URL::Hasher do
       expect(Twingly::URL::Hasher.autopingdb_hash("http://blog.twingly.com/")).to eq expected
     end
   end
-
-  describe ".pingloggerdb_hash" do
-    it "returns a SHA256 64-bit unsigned, native endian digest" do
-      expect(Twingly::URL::Hasher.pingloggerdb_hash("http://blog.twingly.com/")).to eq 15340752212397415993
-    end
-  end
 end


### PR DESCRIPTION
The database is going away so we won't have any need for this.