### PR TITLE
Freeze string literals and mutable constants

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org/'
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Bundler rake tasks to handle gem releases
 require "bundler/gem_tasks"
 

--- a/examples/url.rb
+++ b/examples/url.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "bundler/setup"
 require_relative "../lib/twingly/url"
 

--- a/lib/twingly/public_suffix_list.rb
+++ b/lib/twingly/public_suffix_list.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "addressable/idna"
 require "public_suffix"
 

--- a/lib/twingly/url.rb
+++ b/lib/twingly/url.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "addressable/idna/pure"
 require "addressable/uri"
 require "public_suffix"
@@ -11,14 +13,14 @@ module Twingly
   class URL
     include Comparable
 
-    ACCEPTED_SCHEMES = /\Ahttps?\z/i
+    ACCEPTED_SCHEMES = /\Ahttps?\z/i.freeze
     CUSTOM_PSL = PublicSuffixList.with_punycoded_names
-    ENDS_WITH_SLASH = /\/+$/
+    ENDS_WITH_SLASH = /\/+$/.freeze
     ERRORS_TO_EXTEND = [
       Addressable::IDNA::PunycodeBigOutput,
       Addressable::URI::InvalidURIError,
       PublicSuffix::DomainInvalid,
-    ]
+    ].freeze
 
     private_constant :ACCEPTED_SCHEMES
     private_constant :CUSTOM_PSL

--- a/lib/twingly/url.rb
+++ b/lib/twingly/url.rb
@@ -25,6 +25,7 @@ module Twingly
 
     private_constant :ACCEPTED_SCHEMES
     private_constant :CUSTOM_PSL
+    private_constant :STARTS_WITH_WWW
     private_constant :ENDS_WITH_SLASH
     private_constant :ERRORS_TO_EXTEND
 

--- a/lib/twingly/url.rb
+++ b/lib/twingly/url.rb
@@ -16,6 +16,7 @@ module Twingly
     ACCEPTED_SCHEMES = /\Ahttps?\z/i.freeze
     CUSTOM_PSL = PublicSuffixList.with_punycoded_names
     ENDS_WITH_SLASH = /\/+$/.freeze
+    STARTS_WITH_WWW = /\Awww\./i.freeze
     ERRORS_TO_EXTEND = [
       Addressable::IDNA::PunycodeBigOutput,
       Addressable::URI::InvalidURIError,
@@ -205,7 +206,7 @@ module Twingly
 
     def normalize_blogspot(host, domain)
       if domain.sld.downcase == "blogspot"
-        host.sub(/\Awww\./i, "").sub(/#{domain.tld}\z/i, "com")
+        host.sub(STARTS_WITH_WWW, "").sub(/#{domain.tld}\z/i, "com")
       else
         host
       end

--- a/lib/twingly/url/error.rb
+++ b/lib/twingly/url/error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Twingly
   class URL
     module Error

--- a/lib/twingly/url/hasher.rb
+++ b/lib/twingly/url/hasher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'digest'
 
 require "twingly/url"

--- a/lib/twingly/url/null_url.rb
+++ b/lib/twingly/url/null_url.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Twingly
   class URL
     class NullURL

--- a/lib/twingly/url/utilities.rb
+++ b/lib/twingly/url/utilities.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "twingly/url"
 
 module Twingly

--- a/lib/twingly/version.rb
+++ b/lib/twingly/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Twingly
   class URL
     VERSION = "5.1.1"

--- a/profile/Gemfile
+++ b/profile/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org/"
 
 gem "rake"

--- a/profile/Rakefile
+++ b/profile/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "twingly/url"
 require_relative "profile"
 

--- a/profile/profile.rb
+++ b/profile/profile.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "ruby-prof"
 
 class Profile

--- a/spec/lib/twingly/public_suffix_list_spec.rb
+++ b/spec/lib/twingly/public_suffix_list_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 require "twingly/public_suffix_list"

--- a/spec/lib/twingly/url/hasher_spec.rb
+++ b/spec/lib/twingly/url/hasher_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 require "twingly/url/hasher"

--- a/spec/lib/twingly/url/null_url_spec.rb
+++ b/spec/lib/twingly/url/null_url_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 require "twingly/url"

--- a/spec/lib/twingly/url/utilities_spec.rb
+++ b/spec/lib/twingly/url/utilities_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 require "twingly/url/utilities"

--- a/spec/lib/twingly/url_spec.rb
+++ b/spec/lib/twingly/url_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 require "twingly/url"
@@ -134,7 +136,7 @@ describe Twingly::URL do
     end
 
     context "when given ASCII input" do
-      let(:ascii_url) { "http://www.twingly.com/öあ".force_encoding("ASCII-8BIT") }
+      let(:ascii_url) { "http://www.twingly.com/öあ".dup.force_encoding("ASCII-8BIT") }
       let(:expected)  { "http://www.twingly.com/öあ" }
       let(:actual)    { described_class.parse(ascii_url).to_s }
 

--- a/spec/lib/twingly/url_spec.rb
+++ b/spec/lib/twingly/url_spec.rb
@@ -136,7 +136,7 @@ describe Twingly::URL do
     end
 
     context "when given ASCII input" do
-      let(:ascii_url) { "http://www.twingly.com/öあ".dup.force_encoding("ASCII-8BIT") }
+      let(:ascii_url) { (+"http://www.twingly.com/öあ").force_encoding("ASCII-8BIT") }
       let(:expected)  { "http://www.twingly.com/öあ" }
       let(:actual)    { described_class.parse(ascii_url).to_s }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true

--- a/twingly-url.gemspec
+++ b/twingly-url.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path('../lib/twingly/version', __FILE__)
 
 Gem::Specification.new do |s|


### PR DESCRIPTION
I did this with rubocop:

    rubocop --only Style/FrozenStringLiteralComment,Style/MutableConstant --auto-correct

Opted to not add rubocop at this stage, wanted to limit the amount of
work here.