### PR TITLE
Implement uniqueness (hash equality)

### DIFF
--- a/lib/twingly/url.rb
+++ b/lib/twingly/url.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "digest"
-
 require "addressable/idna/pure"
 require "addressable/uri"
 require "public_suffix"
@@ -24,11 +22,6 @@ module Twingly
       Addressable::URI::InvalidURIError,
       PublicSuffix::DomainInvalid,
     ].freeze
-
-    # Instantiate digest classes in a thread-safe manner
-    # This is important since we don't know how people will
-    # use this gem (if they require it in a thread safe way)
-    SHA256_DIGEST = Digest(:SHA256)
 
     private_constant :ACCEPTED_SCHEMES
     private_constant :CUSTOM_PSL
@@ -205,7 +198,7 @@ module Twingly
     end
 
     def hash
-      SHA256_DIGEST.digest(self.to_s).unpack1("q")
+      self.to_s.hash
     end
 
     def to_s

--- a/lib/twingly/url.rb
+++ b/lib/twingly/url.rb
@@ -194,6 +194,8 @@ module Twingly
     end
 
     def eql?(other)
+      return false unless other.is_a?(self.class)
+
       self.hash == other.hash
     end
 

--- a/lib/twingly/url/null_url.rb
+++ b/lib/twingly/url/null_url.rb
@@ -25,6 +25,8 @@ module Twingly
       end
 
       def eql?(other)
+        return false unless other.is_a?(self.class)
+
         self.hash == other.hash
       end
 

--- a/lib/twingly/url/null_url.rb
+++ b/lib/twingly/url/null_url.rb
@@ -24,6 +24,14 @@ module Twingly
         self.to_s <=> other.to_s
       end
 
+      def eql?(other)
+        self.hash == other.hash
+      end
+
+      def hash
+        "".hash
+      end
+
       def to_s
         ""
       end

--- a/lib/twingly/url/null_url.rb
+++ b/lib/twingly/url/null_url.rb
@@ -29,7 +29,7 @@ module Twingly
       end
 
       def hash
-        "".hash
+        self.to_s.hash
       end
 
       def to_s

--- a/spec/lib/twingly/url/null_url_spec.rb
+++ b/spec/lib/twingly/url/null_url_spec.rb
@@ -104,5 +104,14 @@ describe Twingly::URL::NullURL do
 
       it { is_expected.to eq([described_class.new]) }
     end
+
+    context "an object and its string representation" do
+      let(:a) { described_class.new }
+      let(:b) { described_class.new.to_s }
+
+      it "should be two unique objects" do
+        expect([a,b].uniq).to eq([a,b])
+      end
+    end
   end
 end

--- a/spec/lib/twingly/url/null_url_spec.rb
+++ b/spec/lib/twingly/url/null_url_spec.rb
@@ -112,6 +112,11 @@ describe Twingly::URL::NullURL do
       it "should be two unique objects" do
         expect([a,b].uniq).to eq([a,b])
       end
+
+      describe "#eql?" do
+        subject { a.eql?(b) }
+        it { is_expected.to eq(false) }
+      end
     end
   end
 end

--- a/spec/lib/twingly/url/null_url_spec.rb
+++ b/spec/lib/twingly/url/null_url_spec.rb
@@ -97,4 +97,12 @@ describe Twingly::URL::NullURL do
       expect { url.method_does_not_exist }.to raise_error(NoMethodError)
     end
   end
+
+  describe "uniqueness" do
+    context "a list with multiple NullURLs should only have one unique item" do
+      subject(:list) { 10.times.map { described_class.new }.uniq }
+
+      it { is_expected.to eq([described_class.new]) }
+    end
+  end
 end

--- a/spec/lib/twingly/url_spec.rb
+++ b/spec/lib/twingly/url_spec.rb
@@ -875,6 +875,16 @@ describe Twingly::URL do
         expect([a,b].uniq).to eq([a])
       end
     end
+
+    context "an object and its string representation" do
+      let(:url) { "https://www.twingy.com/" }
+      let(:a) { described_class.parse(url) }
+      let(:b) { described_class.parse(url).to_s }
+
+      it "should be two unique objects" do
+        expect([a,b].uniq).to eq([a,b])
+      end
+    end
   end
 
   describe "#inspect" do

--- a/spec/lib/twingly/url_spec.rb
+++ b/spec/lib/twingly/url_spec.rb
@@ -847,6 +847,36 @@ describe Twingly::URL do
     end
   end
 
+  describe "uniqueness" do
+    context do "with the same URL twice"
+      let(:a) { described_class.parse("https://www.twingly.com/") }
+      let(:b) { described_class.parse("https://www.google.com/") }
+      let(:c) { described_class.parse("https://www.twingly.com/") }
+
+      it "should give only unique URLs" do
+        expect([a,b,c].uniq).to eq([a,b])
+      end
+    end
+
+    context do "two similar URLs, but not exactly the same"
+      let(:a) { described_class.parse("https://www.twingly.com") }
+      let(:b) { described_class.parse("https://www.twingly.com/") }
+
+      it "should be two unique URLs" do
+        expect([a,b].uniq).to eq([a,b])
+      end
+    end
+
+    context do "the same URL but with some whitespace should be the same"
+      let(:a) { described_class.parse(" https://www.twingly.com/") }
+      let(:b) { described_class.parse("https://www.twingly.com/ ") }
+
+      it "should be one unique URL" do
+        expect([a,b].uniq).to eq([a])
+      end
+    end
+  end
+
   describe "#inspect" do
     let(:url_object) { described_class.parse(url) }
     subject { url_object.inspect }

--- a/spec/lib/twingly/url_spec.rb
+++ b/spec/lib/twingly/url_spec.rb
@@ -874,6 +874,11 @@ describe Twingly::URL do
       it "should be one unique URL" do
         expect([a,b].uniq).to eq([a])
       end
+
+      describe ".eql?" do
+        subject { a.eql?(b) }
+        it { is_expected.to eq(true) }
+      end
     end
 
     context "an object and its string representation" do
@@ -883,6 +888,11 @@ describe Twingly::URL do
 
       it "should be two unique objects" do
         expect([a,b].uniq).to eq([a,b])
+      end
+
+      describe "#eql?" do
+        subject { a.eql?(b) }
+        it { is_expected.to eq(false) }
       end
     end
   end


### PR DESCRIPTION
Will reduce duplicates when using `.uniq`, to get even better result the user could first normalize, then uniq.

Close #123