### PR TITLE
Accept that parsing downcases the scheme part, allow Addressable 2.6

### DIFF
--- a/spec/lib/twingly/url_spec.rb
+++ b/spec/lib/twingly/url_spec.rb
@@ -55,7 +55,6 @@ def valid_urls
   [
     "http://blog.twingly.com/",
     "http://blOg.tWingly.coM/",
-    "hTTP://blog.twingly.com/",
     "https://blog.twingly.com",
     "http://3.bp.blogspot.com/_lRbEHeizXlQ/Sf4RdEqCqhI/AAAAAAAAAAw/Pl8nGPsyhXc/s1600-h/images[4].jpg",
     "http://xn--zckp1cyg1.sblo.jp/",
@@ -133,6 +132,13 @@ describe Twingly::URL do
           expect(actual).to be_a(Twingly::URL::NullURL)
         end
       end
+    end
+
+    context "downcases the protocol" do
+      let(:test_url) { "HTTPS://www.twingly.com/" }
+      let(:expected) { "https://www.twingly.com/" }
+
+      it { is_expected.to eq(expected) }
     end
 
     context "when given badly encoded input" do

--- a/spec/lib/twingly/url_spec.rb
+++ b/spec/lib/twingly/url_spec.rb
@@ -532,7 +532,7 @@ describe Twingly::URL do
       it { is_expected.to eq(expected) }
     end
 
-    context "is able to normalize a url without protocol" do
+    context "is able to normalize a url without the scheme part" do
       let(:url)      { "www.twingly.com/" }
       let(:expected) { "http://www.twingly.com/" }
 
@@ -572,7 +572,7 @@ describe Twingly::URL do
       it { is_expected.to eq(expected) }
     end
 
-    context "downcases the protocol" do
+    context "downcases the scheme part" do
       let(:url)      { "HTTPS://www.twingly.com/" }
       let(:expected) { "https://www.twingly.com/" }
 

--- a/spec/lib/twingly/url_spec.rb
+++ b/spec/lib/twingly/url_spec.rb
@@ -134,11 +134,13 @@ describe Twingly::URL do
       end
     end
 
-    context "downcases the protocol" do
+    context "when given URL with uppercase scheme" do
       let(:test_url) { "HTTPS://www.twingly.com/" }
       let(:expected) { "https://www.twingly.com/" }
 
-      it { is_expected.to eq(expected) }
+      it "downcases the scheme part" do
+        expect(subject).to eq(expected)
+      end
     end
 
     context "when given badly encoded input" do

--- a/twingly-url.gemspec
+++ b/twingly-url.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
   s.required_ruby_version = "~> 2.4"
 
-  s.add_dependency "addressable", "~> 2.5.2"
+  s.add_dependency "addressable", "~> 2.6"
   s.add_dependency "public_suffix", "~> 3.0.1"
 
   s.add_development_dependency "rake", "~> 10"


### PR DESCRIPTION
This is the situation since Addressable 2.6: https://github.com/sporkmonger/addressable/pull/281

Close #132