### PR TITLE
Sign in to RubyGems.org before trying to publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,11 +190,11 @@ Note that this isn't a benchmark, we're using [ruby-prof] which will slow things
 
 * Bump the version in `lib/twingly/version.rb` in a commit, no need to push (the release task does that).
 
+* Ensure you are signed in to RubyGems.org as [twingly][twingly-rubygems] with `gem signin`.
+
 * Build and [publish](http://guides.rubygems.org/publishing/) the gem. This will create the proper tag in git, push the commit and tag and upload to RubyGems.
 
         bundle exec rake release
-
-    * If you are not logged in as [twingly][twingly-rubygems] with ruby gems, the rake task will fail and tell you to set credentials via `gem push`, do that and run the `release` task again. It will be okay.
 
 * Update the changelog with [GitHub Changelog Generator](https://github.com/skywinder/github-changelog-generator/) (`gem install github_changelog_generator` if you don't have it, set `CHANGELOG_GITHUB_TOKEN` to a personal access token to avoid rate limiting by GitHub). This command will update `CHANGELOG.md`, commit and push manually.
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ Note that this isn't a benchmark, we're using [ruby-prof] which will slow things
 
         bundle exec rake release
 
-* Update the changelog with [GitHub Changelog Generator](https://github.com/skywinder/github-changelog-generator/) (`gem install github_changelog_generator` if you don't have it, set `CHANGELOG_GITHUB_TOKEN` to a personal access token to avoid rate limiting by GitHub). This command will update `CHANGELOG.md`, commit and push manually.
+* Update the changelog with [GitHub Changelog Generator](https://github.com/skywinder/github-changelog-generator/) (`gem install github_changelog_generator` if you don't have it, set `CHANGELOG_GITHUB_TOKEN` to a personal access token to avoid rate limiting by GitHub). This command will update `CHANGELOG.md`. You need to commit and push manually.
 
         github_changelog_generator
 


### PR DESCRIPTION
I was not signed in when I attempted to publish the gem:

    $ bundle exec rake release
    twingly-url 6.0.1 built to pkg/twingly-url-6.0.1.gem.
    Tagged v6.0.1.
    Pushed git commits and tags.
    rake aborted!
    Your rubygems.org credentials aren't set. Run `gem push` to set them.
    /Users/dentarg/.gem/ruby/2.6.1/bin/bundle:23:in `load'
    /Users/dentarg/.gem/ruby/2.6.1/bin/bundle:23:in `<main>'
    Tasks: TOP => release => release:rubygem_push
    (See full trace by running task with --trace)

I was not supposed to follow the instructions verbatim:

    $ gem push
    ERROR:  While executing gem ... (Gem::CommandLineError)
        Please specify a gem name on the command line (e.g. gem build GEMNAME)

Oh well

    $ gem push pkg/twingly-url-6.0.1.gem
    Enter your RubyGems.org credentials.
    Don't have an account yet? Create one at https://rubygems.org/sign_up
       Email:   red@cted
    Password:

    Signed in.
    Pushing gem to https://rubygems.org...
    Successfully registered gem: twingly-url (6.0.1)

But it wasn't okay 😢

    $ bundle exec rake release
    twingly-url 6.0.1 built to pkg/twingly-url-6.0.1.gem.
    Tag v6.0.1 has already been created.
    rake aborted!
    Pushing gem to https://rubygems.org...
    Repushing of gem versions is not allowed.
    Please use `gem yank` to remove bad gem releases.
    /Users/dentarg/.gem/ruby/2.6.1/bin/bundle:23:in `load'
    /Users/dentarg/.gem/ruby/2.6.1/bin/bundle:23:in `<main>'
    Tasks: TOP => release => release:rubygem_push
    (See full trace by running task with --trace)

I'm not sure, but this possibly screwed with my repo as
github_changelog_generator didn't work after this. Tried it several
times, each time it seemed to hang on

    Fetching tags dates: 11/13

but then it crashed

    Found 13 tags
    #<Thread:0x00007fc63ea96ff8@/Users/dentarg/.gem/ruby/2.6.1/gems/github_changelog_generator-1.14.3/lib/github_changelog_generator/generator/generator_fetcher.rb:26 run> terminated with exception (report_on_exception is true):
    Traceback (most recent call last):
        33: from /Users/dentarg/.gem/ruby/2.6.1/gems/github_changelog_generator-1.14.3/lib/github_changelog_generator/generator/generator_fetcher.rb:27:in `block (2 levels) in fetch_tags_dates'
        32: from /Users/dentarg/.gem/ruby/2.6.1/gems/github_changelog_generator-1.14.3/lib/github_changelog_generator/generator/generator_tags.rb:57:in `get_time_of_tag'
        31: from /Users/dentarg/.gem/ruby/2.6.1/gems/github_changelog_generator-1.14.3/lib/github_changelog_generator/octo_fetcher.rb:212:in `fetch_date_of_tag'
        30: from /Users/dentarg/.gem/ruby/2.6.1/gems/github_changelog_generator-1.14.3/lib/github_changelog_generator/octo_fetcher.rb:295:in `check_github_response'
        29: from /Users/dentarg/.gem/ruby/2.6.1/gems/retriable-2.1.0/lib/retriable.rb:48:in `retriable'
        28: from /Users/dentarg/.gem/ruby/2.6.1/gems/retriable-2.1.0/lib/retriable.rb:48:in `times'
        27: from /Users/dentarg/.gem/ruby/2.6.1/gems/retriable-2.1.0/lib/retriable.rb:54:in `block in retriable'
        26: from /Users/dentarg/.gem/ruby/2.6.1/gems/github_changelog_generator-1.14.3/lib/github_changelog_generator/octo_fetcher.rb:296:in `block in check_github_response'
        25: from /Users/dentarg/.gem/ruby/2.6.1/gems/github_changelog_generator-1.14.3/lib/github_changelog_generator/octo_fetcher.rb:212:in `block in fetch_date_of_tag'
        24: from /Users/dentarg/.gem/ruby/2.6.1/gems/octokit-4.13.0/lib/octokit/client/commits.rb:152:in `commit'
        23: from /Users/dentarg/.gem/ruby/2.6.1/gems/octokit-4.13.0/lib/octokit/connection.rb:19:in `get'
        22: from /Users/dentarg/.gem/ruby/2.6.1/gems/octokit-4.13.0/lib/octokit/connection.rb:156:in `request'
        21: from /Users/dentarg/.gem/ruby/2.6.1/gems/sawyer-0.8.1/lib/sawyer/agent.rb:94:in `call'
        20: from /Users/dentarg/.gem/ruby/2.6.1/gems/faraday-0.15.4/lib/faraday/connection.rb:138:in `get'
        19: from /Users/dentarg/.gem/ruby/2.6.1/gems/faraday-0.15.4/lib/faraday/connection.rb:387:in `run_request'
        18: from /Users/dentarg/.gem/ruby/2.6.1/gems/faraday-0.15.4/lib/faraday/rack_builder.rb:143:in `build_response'
        17: from /Users/dentarg/.gem/ruby/2.6.1/gems/faraday-http-cache-2.0.0/lib/faraday/http_cache.rb:115:in `call'
        16: from /Users/dentarg/.gem/ruby/2.6.1/gems/faraday-http-cache-2.0.0/lib/faraday/http_cache.rb:142:in `call!'
        15: from /Users/dentarg/.gem/ruby/2.6.1/gems/faraday-http-cache-2.0.0/lib/faraday/http_cache.rb:201:in `process'
        14: from /Users/dentarg/.gem/ruby/2.6.1/gems/faraday-http-cache-2.0.0/lib/faraday/http_cache.rb:223:in `validate'
        13: from /Users/dentarg/.gem/ruby/2.6.1/gems/faraday-0.15.4/lib/faraday/response.rb:8:in `call'
        12: from /Users/dentarg/.gem/ruby/2.6.1/gems/faraday-0.15.4/lib/faraday/adapter/net_http.rb:38:in `call'
        11: from /Users/dentarg/.gem/ruby/2.6.1/gems/faraday-0.15.4/lib/faraday/adapter/net_http.rb:92:in `with_net_http_connection'
        10: from /Users/dentarg/.gem/ruby/2.6.1/gems/faraday-0.15.4/lib/faraday/adapter/net_http.rb:43:in `block in call'
         9: from /Users/dentarg/.gem/ruby/2.6.1/gems/faraday-0.15.4/lib/faraday/adapter/net_http.rb:85:in `perform_request'
         8: from /Users/dentarg/.rubies/ruby-2.6.1/lib/ruby/2.6.0/net/http.rb:1228:in `get'
         7: from /Users/dentarg/.rubies/ruby-2.6.1/lib/ruby/2.6.0/net/http.rb:1470:in `request'
         6: from /Users/dentarg/.rubies/ruby-2.6.1/lib/ruby/2.6.0/net/http.rb:919:in `start'
         5: from /Users/dentarg/.rubies/ruby-2.6.1/lib/ruby/2.6.0/net/http.rb:930:in `do_start'
         4: from /Users/dentarg/.rubies/ruby-2.6.1/lib/ruby/2.6.0/net/http.rb:945:in `connect'
         3: from /Users/dentarg/.rubies/ruby-2.6.1/lib/ruby/2.6.0/timeout.rb:103:in `timeout'
         2: from /Users/dentarg/.rubies/ruby-2.6.1/lib/ruby/2.6.0/net/http.rb:947:in `block in connect'
         1: from /Users/dentarg/.rubies/ruby-2.6.1/lib/ruby/2.6.0/net/http.rb:947:in `open'
    /Users/dentarg/.rubies/ruby-2.6.1/lib/ruby/2.6.0/net/http.rb:947:in `initialize': execution expired (Net::OpenTimeout)

I had no problem using github_changelog_generator on another computer.
Same version (1.14.3) and Ruby (2.6.1).