### PR TITLE
Handle some common representations of newlines

### DIFF
--- a/lib/twingly/url.rb
+++ b/lib/twingly/url.rb
@@ -22,9 +22,13 @@ module Twingly
       Addressable::URI::InvalidURIError,
       PublicSuffix::DomainInvalid,
     ].freeze
+    CARRIAGE_RETURN = "\u000D"
+    LINE_FEED = "\u000A"
     NBSP = "\u00A0"
     SPACE = "\u0020"
     WHITESPACE_CHARS = [
+      CARRIAGE_RETURN,
+      LINE_FEED,
       NBSP,
       SPACE,
     ].join.freeze

--- a/spec/lib/twingly/url_spec.rb
+++ b/spec/lib/twingly/url_spec.rb
@@ -70,6 +70,8 @@ def valid_urls
 end
 
 def leading_and_trailing_whitespace
+  line_feed          = "\u000A"
+  carriage_return    = "\u000D"
   non_breaking_space = "\u00A0"
   space              = "\u0020"
 
@@ -79,6 +81,19 @@ def leading_and_trailing_whitespace
     "non-breaking space, space, non-breaking space" => [non_breaking_space, space, non_breaking_space].join,
     "space and non-breaking space"                  => [space, non_breaking_space].join,
     "space, non-breaking space and space"           => [space, non_breaking_space, space].join,
+
+    "non-breaking space and line-feed"              => [non_breaking_space, line_feed].join,
+    "line-feed and non-breaking space"              => [line_feed, non_breaking_space].join,
+    "space and line-feed"                           => [space, line_feed].join,
+    "line-feed and space"                           => [line_feed, space].join,
+
+    "non-breaking space and carriage-return"        => [non_breaking_space, carriage_return].join,
+    "carriage-return and non-breaking space"        => [carriage_return, non_breaking_space].join,
+    "space and carriage-return"                     => [space, carriage_return].join,
+    "carriage-return and space"                     => [carriage_return, space].join,
+
+    "carriage-return and line-feed"                 => [carriage_return, line_feed].join,
+    "line-feed and carriage-return"                 => [line_feed, carriage_return].join,
   }
 end
 

--- a/spec/lib/twingly/url_spec.rb
+++ b/spec/lib/twingly/url_spec.rb
@@ -70,12 +70,15 @@ def valid_urls
 end
 
 def leading_and_trailing_whitespace
+  non_breaking_space = "\u00A0"
+  space              = "\u0020"
+
   {
-    "non-breaking space and space" => "\u00A0\u0020",
-    "non-breaking space" => "\u00A0",
-    "non-breaking space, space, non-breaking space" => "\u00A0\u0020\u00A0",
-    "space and non-breaking space" => "\u0020\u00A0",
-    "space, non-breaking space and space" => "\u0020\u00A0\u0020",
+    "non-breaking space and space"                  => [non_breaking_space, space].join,
+    "non-breaking space"                            => [non_breaking_space].join,
+    "non-breaking space, space, non-breaking space" => [non_breaking_space, space, non_breaking_space].join,
+    "space and non-breaking space"                  => [space, non_breaking_space].join,
+    "space, non-breaking space and space"           => [space, non_breaking_space, space].join,
   }
 end
 


### PR DESCRIPTION
There are a few more, https://en.wikipedia.org/wiki/Newline#Unicode, maybe we can add them later if need be.

What triggered this was a need to parse a list of URLs where some ended with non-breaking space followed by line-feed:

```ruby
$ irb -rtwingly/url
irb(main):001:0> Twingly::URL.parse("https://www.example.com\u00A0\n")
=> #<Twingly::URL::NullURL:0x00007f8442004100>
irb(main):002:0> Twingly::URL::VERSION
=> "5.1.0"
```
