### PR TITLE
Add version constraint for Pry

### DIFF
--- a/twingly-url.gemspec
+++ b/twingly-url.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rake", "~> 12"
   s.add_development_dependency "rspec", "~> 3"
-  s.add_development_dependency "pry"
+  s.add_development_dependency "pry", "~> 0"
 
   s.files        = Dir.glob("{lib}/**/*") + %w(README.md)
   s.require_path = 'lib'


### PR DESCRIPTION
Takes care of the following warning when building the gem:

```
WARNING:  open-ended dependency on pry (>= 0, development) is not recommended
  use a bounded requirement, such as '~> x.y'
```