### PR TITLE
Run CI on latest Rubies

### DIFF
--- a/.github/workflows/ci-build-and-install-gem.yml
+++ b/.github/workflows/ci-build-and-install-gem.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7.2
+        ruby-version: 2.7.3
 
     - name: Build and install gem
       run: gem build *.gemspec && gem install *.gem

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { ruby: 2.5.8 }
-          - { ruby: 2.6.6 }
-          - { ruby: 2.7.2 }
-          - { ruby: 3.0.0 }
+          - { ruby: 2.6.7 }
+          - { ruby: 2.7.3 }
+          - { ruby: 3.0.1 }
           - { ruby: head, allow-failure: true }
-          - { ruby: jruby-9.2.13.0 }
+          - { ruby: jruby-9.2.17.0 }
           - { ruby: jruby-head, allow-failure: true }
 
     steps:


### PR DESCRIPTION
Removed Ruby 2.5 from matrix as it went EoL 2021-03-31.