### PR TITLE
Remove `Twingly::URL::Hasher.blogstream_hash`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Twingly URL tools.
     * `Twingly::URL.parse` - Returns one or more `Twingly::URL` instance
 * `twingly/url/hasher` - Generate URL hashes suitable for primary keys
     * `Twingly::URL::Hasher.taskdb_hash(url)` - MD5 hexdigest
-    * `Twingly::URL::Hasher.blogstream_hash(url)` - MD5 hexdigest
     * `Twingly::URL::Hasher.documentdb_hash(url)` - SHA256 unsigned long, native endian digest
     * `Twingly::URL::Hasher.autopingdb_hash(url)` - SHA256 64-bit signed, native endian digest
 * `twingly/url/utilities` - Utilities to work with URLs

--- a/lib/twingly/url/hasher.rb
+++ b/lib/twingly/url/hasher.rb
@@ -19,10 +19,6 @@ module Twingly
         MD5_DIGEST.hexdigest(url)[0..29].upcase
       end
 
-      def blogstream_hash(url)
-        MD5_DIGEST.hexdigest(url)[0..29].upcase
-      end
-
       def documentdb_hash(url)
         SHA256_DIGEST.digest(url).unpack("L!")[0]
       end

--- a/spec/lib/twingly/url/hasher_spec.rb
+++ b/spec/lib/twingly/url/hasher_spec.rb
@@ -11,12 +11,6 @@ describe Twingly::URL::Hasher do
     end
   end
 
-  describe ".blogstream_hash" do
-    it "returns a MD5 hexdigest" do
-      expect(Twingly::URL::Hasher.blogstream_hash("http://blog.twingly.com/")).to eq "B1E2D5AECF6649C2E44D17AEA3E0F4"
-    end
-  end
-
   describe ".documentdb_hash" do
     it "returns a SHA256 unsigned long, native endian digest" do
       expect(Twingly::URL::Hasher.documentdb_hash("http://blog.twingly.com/")).to eq 15340752212397415993


### PR DESCRIPTION
Since blogbox have been decomissioned and blogstream is on its way out,
the code removed in this commit would have been dead code if left behind.

See issue: https://github.com/twingly/twingly-url/issues/152
See Trello: https://trello.com/c/x2KWY2Mo/3686-sprint108-avveckla-blog-box

close https://github.com/twingly/twingly-url/issues/152