### PR TITLE
Allow use of `public_suffix` 5

### DIFF
--- a/twingly-url.gemspec
+++ b/twingly-url.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.5"
 
   s.add_dependency "addressable", "~> 2.6"
-  s.add_dependency "public_suffix", ">= 3.0.1", "< 5.0"
+  s.add_dependency "public_suffix", ">= 3.0.1", "< 6.0"
 
   s.add_development_dependency "rake", "~> 12"
   s.add_development_dependency "rspec", "~> 3"


### PR DESCRIPTION
Changes in `public_suffix` looks fine to me, no breaking API changes what I can see:

* https://github.com/weppos/publicsuffix-ruby/blob/v5.0.0/CHANGELOG.md#500
* https://github.com/weppos/publicsuffix-ruby/compare/v4.0.7...v5.0.0

Addressable 2.8.1 was just released to allow use of public_suffix 5.x:
https://github.com/sporkmonger/addressable/blob/addressable-2.8.1/CHANGELOG.md#addressable-281