### PR TITLE
CI housekeeping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup Ruby ${{ matrix.ruby }}
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { ruby: 2.7.6 }
-          - { ruby: 3.0.4 }
-          - { ruby: 3.1.2 }
+          - { ruby: '2.7' }
+          - { ruby: '3.0' }
+          - { ruby: '3.1' }
           - { ruby: head, allow-failure: true }
-          - { ruby: jruby-9.3.4.0 }
+          - { ruby: jruby-9.3 }
           - { ruby: jruby-head, allow-failure: true }
 
     steps:


### PR DESCRIPTION
Use latest checkout action: https://github.com/actions/checkout/blob/main/CHANGELOG.md

Use Ubuntu 20.04 as 18.04 is going away soon: https://github.com/actions/runner-images/issues/6002