### PR TITLE
Require Ruby >= 2.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - { ruby: '2.6' }
           - { ruby: '2.7' }
           - { ruby: '3.0' }
           - { ruby: '3.1' }

--- a/twingly-url.gemspec
+++ b/twingly-url.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.summary     = "Ruby library for URL handling"
   s.description = "Twingly URL tools"
   s.license     = "MIT"
-  s.required_ruby_version = ">= 2.5"
+  s.required_ruby_version = ">= 2.7"
 
   s.add_dependency "addressable", "~> 2.6"
   s.add_dependency "public_suffix", ">= 3.0.1", "< 5.0"

--- a/twingly-url.gemspec
+++ b/twingly-url.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.summary     = "Ruby library for URL handling"
   s.description = "Twingly URL tools"
   s.license     = "MIT"
-  s.required_ruby_version = ">= 2.7"
+  s.required_ruby_version = ">= 2.6"
 
   s.add_dependency "addressable", "~> 2.6"
   s.add_dependency "public_suffix", ">= 3.0.1", "< 6.0"


### PR DESCRIPTION
Both Ruby 2.5 and 2.6 have reached EOL, but JRuby 9.3 still requires Ruby 2.6, which is why we have to allow it.