### PR TITLE
Validate the normalized hostname

### DIFF
--- a/spec/lib/twingly/url_spec.rb
+++ b/spec/lib/twingly/url_spec.rb
@@ -39,6 +39,7 @@ def invalid_urls
     "http://.gl/xxx",
     "http://.twingly.com/",
     "http://www.twingly.",
+    "http://www..twingly..com/",
 
     # Test that we can handle upstream bug in Addressable, references:
     # https://github.com/twingly/twingly-url/issues/62
@@ -562,12 +563,6 @@ describe Twingly::URL do
       let(:expected) { "" }
 
       it { is_expected.to eq(expected) }
-    end
-
-    context "oddly enough, does not alter URLs with consecutive dots" do
-      let(:url) { "http://www..twingly..com/" }
-
-      it { is_expected.to eq(url) }
     end
 
     context "does not add www. to blogspot URLs" do


### PR DESCRIPTION
According to the "preferred format" used by DNS.

See https://en.wikipedia.org/wiki/Domain_Name_System#Domain_name_syntax,_internationalization

Moves one invalid URL to the set of invalid URLs (if you enter http://www..twingly..com/ in the address bar in Chrome, it does a search, doesn't try to visit any site).

Close #62