### PR TITLE
Update CI workflow

### DIFF
--- a/.github/workflows/ci-build-and-install-gem.yml
+++ b/.github/workflows/ci-build-and-install-gem.yml
@@ -6,11 +6,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1


### PR DESCRIPTION
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Updated ubuntu and `actions/checkout` versions.