### PR TITLE
Don't redo the parsing when normalizing the url.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ RSpec.configure do |config|
   end
 
   config.order = :random
+  config.filter_run_when_matching :focus
 
   Kernel.srand config.seed
 end


### PR DESCRIPTION
The parsing isn't redone when calling normalized. 
I don't want to make any big changes in the this gem right now. But this is minimal change that will do a significant speedup with what I consider a low risk of introducing changed behavior/bugs. 
