### PR TITLE
Allow public_suffix v7, bump versions in CI

### DIFF
--- a/.github/workflows/ci-build-and-install-gem.yml
+++ b/.github/workflows/ci-build-and-install-gem.yml
@@ -6,16 +6,16 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
 
     - name: Setup Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.1.2
+        ruby-version: ruby
 
     - name: Build and install gem
       run: gem build *.gemspec && gem install *.gem

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
@@ -17,13 +17,15 @@ jobs:
           - { ruby: '3.0' }
           - { ruby: '3.1' }
           - { ruby: '3.2' }
+          - { ruby: '3.3' }
+          - { ruby: '3.4' }
           - { ruby: head, allow-failure: true }
-          - { ruby: jruby-9.3 }
+          - { ruby: jruby-10.0 }
           - { ruby: jruby-head, allow-failure: true }
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
 
     - name: Setup Ruby ${{ matrix.ruby }}
       uses: ruby/setup-ruby@v1

--- a/spec/lib/twingly/public_suffix_list_spec.rb
+++ b/spec/lib/twingly/public_suffix_list_spec.rb
@@ -24,7 +24,7 @@ describe Twingly::PublicSuffixList do
       let(:encoding) { Encoding::US_ASCII }
       # https://github.com/ruby/ruby/commit/571d21fd4a2e877f49b4ff918832bda9a5e8f91c
       let(:expected_error) do
-        if RUBY_VERSION >= "3.2.0"
+        if RUBY_VERSION >= "3.2.0" && RUBY_ENGINE != "jruby"
           Encoding::CompatibilityError
         else
           ArgumentError

--- a/spec/lib/twingly/url_spec.rb
+++ b/spec/lib/twingly/url_spec.rb
@@ -220,7 +220,7 @@ describe Twingly::URL do
     context "when called from the outside" do
       it "raises an error" do
         expect { described_class.internal_parse("a") }.
-          to raise_error(NoMethodError, /private method `internal_parse' called for/)
+          to raise_error(NoMethodError, /private method (`|')internal_parse' called for/)
       end
     end
   end
@@ -229,7 +229,7 @@ describe Twingly::URL do
     context "when called from the outside" do
       it "raises an error" do
         expect { described_class.new("a", "b") }.
-          to raise_error(NoMethodError, /private method `new' called for/)
+          to raise_error(NoMethodError, /private method (`|')new' called for/)
       end
     end
   end

--- a/twingly-url.gemspec
+++ b/twingly-url.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency "addressable", "~> 2.6"
   s.add_dependency "public_suffix", ">= 3.0.1", "< 8"
 
-  s.add_development_dependency "rake", "~> 12"
+  s.add_development_dependency "rake"
   s.add_development_dependency "rspec", "~> 3"
   s.add_development_dependency "pry", "~> 0"
 

--- a/twingly-url.gemspec
+++ b/twingly-url.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.6"
 
   s.add_dependency "addressable", "~> 2.6"
-  s.add_dependency "public_suffix", ">= 3.0.1", "< 6.0"
+  s.add_dependency "public_suffix", ">= 3.0.1", "< 8"
 
   s.add_development_dependency "rake", "~> 12"
   s.add_development_dependency "rspec", "~> 3"


### PR DESCRIPTION
https://github.com/actions/checkout have been bumping the major version every time they bump the required Node.js version, it does not affect you when you run on GitHub Actions